### PR TITLE
fixes plan cancelation bug

### DIFF
--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -393,8 +393,6 @@ class StripeGateway
                 $this->billable->setSubscriptionEndDate(
                     Carbon::createFromTimestamp($this->getSubscriptionEndTimestamp($customer))
                 );
-            } else {
-                $this->billable->setSubscriptionEndDate(Carbon::now());
             }
 
             $customer->cancelSubscription(['at_period_end' => $atPeriodEnd]);
@@ -403,6 +401,7 @@ class StripeGateway
         if ($atPeriodEnd) {
             $this->billable->setStripeIsActive(false)->saveBillableInstance();
         } else {
+            $this->billable->setSubscriptionEndDate(Carbon::now());
             $this->billable->deactivateStripe()->saveBillableInstance();
         }
     }


### PR DESCRIPTION
if a plan is canceled at the end of the billing period and after is deleted immediately the user will look like this
stripe_active = 0, subscription = null, subscription_ends_at = future

this makes sure that if the subscription_ends_at = now
